### PR TITLE
Remove Claude Desktop config from Homebrew caveats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,17 +130,6 @@ brews:
         • Grant automation permissions to the binary (not Terminal)
         • Run on HTTP transport (localhost:8787 by default)
       
-      Configuration for Claude Desktop:
-        Add to ~/Library/Application Support/Claude/claude_desktop_config.json:
-        
-        {
-          "mcpServers": {
-            "apple-mail": {
-              "url": "http://localhost:8787/mcp/v1"
-            }
-          }
-        }
-      
       To remove the launchd service:
         apple-mail-mcp launchd remove
       


### PR DESCRIPTION
The configuration instructions are better suited for the README where they can be maintained alongside other client examples. Homebrew caveats should focus on installation-specific setup only.