### PR TITLE
Enable goreleaser changelog generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,7 +76,7 @@ brews:
 
     install: |
       bin.install "apple-mail-mcp"
-    
+
     post_install: |
       # Check if launchd service exists and recreate it after upgrade
       # This preserves all settings (port, host, debug, RunAtLoad) from the existing plist
@@ -84,23 +84,23 @@ brews:
       if File.exist?(plist_path)
         # Read the existing plist to extract settings
         plist_content = File.read(plist_path)
-        
+
         # Extract port (default: 8787)
         port = plist_content.match(/--port=(\d+)/)
         port_flag = port ? "--port=#{port[1]}" : ""
-        
+
         # Extract host (default: localhost)
         host = plist_content.match(/--host=([^\s<]+)/)
         host_flag = host ? "--host=#{host[1]}" : ""
-        
+
         # Check if debug is enabled
         has_debug = plist_content.include?("<string>--debug</string>")
         debug_flag = has_debug ? "--debug" : ""
-        
+
         # Check if RunAtLoad is set
         has_run_at_load = plist_content.include?("<key>RunAtLoad</key>")
         run_at_load_flag = has_run_at_load ? "" : "--disable-run-at-load"
-        
+
         # Build command with all flags
         cmd = ["#{bin}/apple-mail-mcp"]
         cmd << port_flag unless port_flag.empty?
@@ -109,35 +109,35 @@ brews:
         cmd << "launchd"
         cmd << "create"
         cmd << run_at_load_flag unless run_at_load_flag.empty?
-        
+
         # Recreate the service preserving all settings
         system(*cmd.reject(&:empty?))
-        
+
         ohai "Recreated launchd service with updated binary (preserved existing settings)"
       end
-    
+
     caveats: |
       Apple Mail MCP Server has been installed!
-      
+
       ⚠️  IMPORTANT: For proper automation permissions, you should run this server
       via launchd (not from Terminal directly).
-      
+
       Setup launchd service (recommended):
         apple-mail-mcp launchd create
-      
+
       This will:
         • Create a launchd service that starts automatically
         • Grant automation permissions to the binary (not Terminal)
         • Run on HTTP transport (localhost:8787 by default)
-      
+
       To remove the launchd service:
         apple-mail-mcp launchd remove
-      
+
       Before uninstalling with 'brew uninstall apple-mail-mcp':
         1. Stop and remove the launchd service: apple-mail-mcp launchd remove
         2. Then run: brew uninstall apple-mail-mcp
         3. Optionally remove logs: rm -rf ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
-      
+
       For more information:
         • README: https://github.com/dastrobu/apple-mail-mcp#readme
         • Docs: https://github.com/dastrobu/apple-mail-mcp/tree/main/docs
@@ -153,8 +153,7 @@ release:
 
   name_template: "v{{ .Version }}"
 
-  # Use GitHub's auto-generated release notes
-  # Configure via .github/release.yml
+  # Appends the changelog to the release body
   mode: append
 
   footer: |
@@ -191,6 +190,10 @@ release:
 
     See the [README](https://github.com/dastrobu/apple-mail-mcp#readme) for usage instructions.
 
-# Changelog - GitHub auto-generates release notes based on .github/release.yml
+# Changelog configuration
 changelog:
-  disable: true
+  sort: asc
+  filters:
+    exclude:
+      - "^Merge pull request"
+      - "^Merge branch"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -162,17 +162,17 @@ Follow [Semantic Versioning](https://semver.org/):
 - **MINOR** version (v1.0.0 → v1.1.0): New features (backwards compatible)
 - **PATCH** version (v1.0.0 → v1.0.1): Bug fixes (backwards compatible)
 
-## Commit Message Conventions
+## Commit Messages
 
-For better changelogs, use conventional commits:
+For clear changelogs, consider using conventional commits (though all non-merge commits will be included):
 
 - `feat:` - New features
 - `fix:` - Bug fixes
 - `perf:` - Performance improvements
-- `docs:` - Documentation changes (excluded from changelog)
-- `test:` - Test changes (excluded from changelog)
-- `ci:` - CI changes (excluded from changelog)
-- `chore:` - Maintenance (excluded from changelog)
+- `docs:` - Documentation changes
+- `test:` - Test changes
+- `ci:` - CI changes
+- `chore:` - Maintenance
 
 Example:
 ```


### PR DESCRIPTION
Enables changelog generation in GoReleaser configuration.

Updates RELEASE.md to reflect that all non-merge commits are now included in the changelog.