### PR TITLE
Add brew services support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,66 +77,31 @@ brews:
     install: |
       bin.install "apple-mail-mcp"
 
-    post_install: |
-      # Check if launchd service exists and recreate it after upgrade
-      # This preserves all settings (port, host, debug, RunAtLoad) from the existing plist
-      plist_path = "#{ENV["HOME"]}/Library/LaunchAgents/com.github.dastrobu.apple-mail-mcp.plist"
-      if File.exist?(plist_path)
-        # Read the existing plist to extract settings
-        plist_content = File.read(plist_path)
-
-        # Extract port (default: 8787)
-        port = plist_content.match(/--port=(\d+)/)
-        port_flag = port ? "--port=#{port[1]}" : ""
-
-        # Extract host (default: localhost)
-        host = plist_content.match(/--host=([^\s<]+)/)
-        host_flag = host ? "--host=#{host[1]}" : ""
-
-        # Check if debug is enabled
-        has_debug = plist_content.include?("<string>--debug</string>")
-        debug_flag = has_debug ? "--debug" : ""
-
-        # Check if RunAtLoad is set
-        has_run_at_load = plist_content.include?("<key>RunAtLoad</key>")
-        run_at_load_flag = has_run_at_load ? "" : "--disable-run-at-load"
-
-        # Build command with all flags
-        cmd = ["#{bin}/apple-mail-mcp"]
-        cmd << port_flag unless port_flag.empty?
-        cmd << host_flag unless host_flag.empty?
-        cmd << debug_flag unless debug_flag.empty?
-        cmd << "launchd"
-        cmd << "create"
-        cmd << run_at_load_flag unless run_at_load_flag.empty?
-
-        # Recreate the service preserving all settings
-        system(*cmd.reject(&:empty?))
-
-        ohai "Recreated launchd service with updated binary (preserved existing settings)"
-      end
+    service: |
+      run [opt_bin/"apple-mail-mcp", "--transport=http"]
+      keep_alive true
+      log_path var/"log/apple-mail-mcp.log"
+      error_log_path var/"log/apple-mail-mcp.err"
+      environment_variables APPLE_MAIL_MCP_PORT: "8787", APPLE_MAIL_MCP_HOST: "localhost"
 
     caveats: |
       Apple Mail MCP Server has been installed!
 
       ⚠️  IMPORTANT: For proper automation permissions, you should run this server
-      via launchd (not from Terminal directly).
+      via launchd or brew services (not from Terminal directly).
 
-      Setup launchd service (recommended):
+      Option 1: Use Homebrew Services (Standard)
+        brew services start apple-mail-mcp
+
+      Option 2: Use custom launchd service (for custom port/debug)
         apple-mail-mcp launchd create
-
-      This will:
-        • Create a launchd service that starts automatically
-        • Grant automation permissions to the binary (not Terminal)
-        • Run on HTTP transport (localhost:8787 by default)
 
       To remove the launchd service:
         apple-mail-mcp launchd remove
 
       Before uninstalling with 'brew uninstall apple-mail-mcp':
-        1. Stop and remove the launchd service: apple-mail-mcp launchd remove
+        1. Stop and remove the service: brew services stop apple-mail-mcp OR apple-mail-mcp launchd remove
         2. Then run: brew uninstall apple-mail-mcp
-        3. Optionally remove logs: rm -rf ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
 
       For more information:
         • README: https://github.com/dastrobu/apple-mail-mcp#readme

--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ brew tap dastrobu/tap
 # Install
 brew install apple-mail-mcp
 
-# Set up launchd service (IMPORTANT for proper permissions)
+# Start the service (Standard)
+brew services start apple-mail-mcp
+
+# OR use the built-in subcommand for more customization (port, debug)
 apple-mail-mcp launchd create
 ```
 
-**Important**: After installation, you must run `apple-mail-mcp launchd create` to set up the launchd service. This ensures automation permissions are granted to the binary itself (not Terminal or Claude Desktop).
+**Important**: For proper automation permissions, you must run the server as a service (not from Terminal). Using `brew services start` is the standard way, while `apple-mail-mcp launchd create` offers more customization.
 
 **Note**: When you upgrade via `brew upgrade apple-mail-mcp`, the launchd service will automatically restart with the new version if it's already running. You don't need to manually recreate the service.
 
@@ -887,17 +890,22 @@ This will recreate the service with the new binary path.
 
 ### Homebrew
 
-**⚠️ IMPORTANT:** Remove the launchd service BEFORE uninstalling:
+**⚠️ IMPORTANT:** Stop the service BEFORE uninstalling:
 
 ```bash
-# Step 1: Remove the launchd service (if you created one)
+# Step 1: Stop the service (whichever method you used)
+brew services stop apple-mail-mcp
+# OR
 apple-mail-mcp launchd remove
 
 # Step 2: Uninstall the package
 brew uninstall apple-mail-mcp
 
-# Step 3 (optional): Remove logs
-rm -rf ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
+# Step 3 (Optional): Remove logs
+# If you used brew services:
+rm $(brew --prefix)/var/log/apple-mail-mcp.*
+# If you used apple-mail-mcp launchd create:
+rm -r ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
 ```
 
 **Why this order matters:** The `launchd remove` command needs the binary to properly unload and remove the service. If you uninstall first, you'll need to manually remove the plist file.
@@ -922,7 +930,7 @@ apple-mail-mcp launchd remove
 rm /usr/local/bin/apple-mail-mcp
 
 # Optionally remove logs
-rm -rf ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
+rm -r ~/Library/Logs/com.github.dastrobu.apple-mail-mcp/
 ```
 
 ## Architecture


### PR DESCRIPTION
This PR adds idiomatic brew services support to the Homebrew formula via GoReleaser and updates the documentation to reflect this as the standard way to manage the service. It also removes legacy post-install scripts to simplify the installation process.