### PR TITLE
perf: fix find_messages timeout on large result sets

### DIFF
--- a/internal/tools/scripts/find_messages.js
+++ b/internal/tools/scripts/find_messages.js
@@ -177,10 +177,10 @@ function run(argv) {
     let filteredMessages;
     if (conditions.length === 1) {
       // Single condition
-      filteredMessages = targetMailbox.messages.whose(conditions[0])();
+      filteredMessages = targetMailbox.messages.whose(conditions[0]);
     } else {
       // Multiple conditions - use _and
-      filteredMessages = targetMailbox.messages.whose({ _and: conditions })();
+      filteredMessages = targetMailbox.messages.whose({ _and: conditions });
     }
 
     const totalMatches = filteredMessages.length;


### PR DESCRIPTION
Fixes #13

This PR optimizes the `find_messages` tool to avoid freezing and timeouts when evaluating a huge result set over Apple Events. 

Previously, `targetMailbox.messages.whose(...)()` evaluated the entire matched message collection into an array of object specifiers upfront, causing significant overhead for large results (e.g. 5000+ messages), even when `limit` was `1`.

By omitting the trailing `()`, the query remains an unevaluated object specifier. The `.length` property can be queried in constant time, and `maxProcess` items are subsequently resolved one by one, dramatically reducing execution time and preventing timeouts.